### PR TITLE
Convert MSSQL DB name to random string to avoid name collisions on mu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Full working references are available at [examples](examples)
 | create_option_group | A boolean variable noting if a new option group should be created. | string | `true` | no |
 | create_parameter_group | A boolean variable noting if a new parameter group should be created. | string | `true` | no |
 | create_subnet_group | A boolean variable noting if a new DB subnet group should be created. | string | `true` | no |
+| db_instance_create_timeout | Timeout in minutes for creating instances, replicas, and restoring from Snapshots | string | - | yes |
+| db_instance_delete_timeout | Timeout in minutes for destroying databases. This includes the time required to take snapshots | string | - | yes |
+| db_instance_update_timeout | Timeout in minutes for datbabse modifications | string | - | yes |
 | db_snapshot_id | The name of a DB snapshot (optional). | string | `` | no |
 | dbname | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | engine | Database Engine Type.  Allowed values: mariadb, mysql, oracle-ee, oracle-se, oracle-se1, oracle-se2, postgres, sqlserver-ee, sqlserver-ex, sqlserver-se, sqlserver-web | string | - | yes |
@@ -97,6 +100,7 @@ Full working references are available at [examples](examples)
 | option_group | The Option Group used by the DB Instance |
 | parameter_group | The Parameter Group used by the DB Instance |
 | subnet_group | The DB Subnet Group used by the DB Instance |
+
 
 ## Troubleshooting / FAQs
 

--- a/main.tf
+++ b/main.tf
@@ -332,6 +332,12 @@ resource "aws_db_instance" "db_instance" {
 
   tags = "${merge(var.tags, local.tags)}"
 
+  timeouts = {
+    create = "${var.db_instance_create_timeout}"
+    update = "${var.db_instance_update_timeout}"
+    delete = "${var.db_instance_delete_timeout}"
+  }
+
   # Option Group, Parameter Group, and Subnet Group added as the coalesce to use any existing groups seems to throw off
   # dependancies while destroying resources
   depends_on = [

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -20,6 +20,14 @@ resource "random_string" "password" {
   min_numeric = 1
 }
 
+resource "random_string" "mssql_name" {
+  length  = 15
+  special = false
+  number  = false
+  lower   = true
+  upper   = false
+}
+
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//"
 
@@ -126,7 +134,7 @@ module "rds_mssql" {
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test-mssql"
+  name                = "${random_string.mssql_name.result}"
   engine              = "sqlserver-se"
   instance_class      = "db.m4.large"
   password            = "${random_string.password.result}"

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,24 @@ variable "dbname" {
   default     = ""
 }
 
+variable "db_instance_create_timeout" {
+  description = "Timeout for creating instances, replicas, and restoring from Snapshots"
+  type        = "string"
+  default     = "60m"
+}
+
+variable "db_instance_update_timeout" {
+  description = "Timeout for datbabse modifications"
+  type        = "string"
+  default     = "80m"
+}
+
+variable "db_instance_delete_timeout" {
+  description = "Timeout for destroying databases. This includes the time required to take snapshots"
+  type        = "string"
+  default     = "60m"
+}
+
 variable "engine" {
   description = "Database Engine Type.  Allowed values: mariadb, mysql, oracle-ee, oracle-se, oracle-se1, oracle-se2, postgres, sqlserver-ee, sqlserver-ex, sqlserver-se, sqlserver-web"
   type        = "string"


### PR DESCRIPTION
Reference: https://trello.com/c/PMKyrpCH/845-bug-rds-test-configuration-does-not-allow-for-synchronous-tests and https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/100
- Convert name to random string to avoid name collisions
- Add timeout variables and set create and delete timeouts to 60 minutes. Many CI failures are seen due to creation timeouts. 