### PR TITLE
[superseded] Fix for error: no matching Route53Zone found

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -426,12 +426,16 @@ resource "aws_db_event_subscription" "default" {
 data "aws_route53_zone" "hosted_zone" {
   count = "${var.internal_record_name != "" ? 1 : 0}"
 
+  depends_on = ["aws_db_instance.db_instance"]
+
   name         = "${var.internal_zone_name}"
   private_zone = true
 }
 
 resource "aws_route53_record" "zone_record_alias" {
   count = "${var.internal_record_name != "" ? 1 : 0}"
+
+  depends_on = ["aws_db_instance.db_instance"]
 
   name    = "${var.internal_record_name}.${data.aws_route53_zone.hosted_zone.name}"
   ttl     = "300"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):

N/A

##### Summary of change(s):

**Note:** this has been performed in a fork since I have no rights to create a branch in this repo

Since switching to the module in CAP Quickstarts we have been plagued by the following error:

```
* module.cap-aws-magento.module.rds_database.data.aws_route53_zone.hosted_zone: 1 error(s) occurred:

* module.cap-aws-magento.module.rds_database.data.aws_route53_zone.hosted_zone: data.aws_route53_zone.hosted_zone: no matching Route53Zone found
```

This occurs on a `terraform apply` following a `terraform destroy`. While the `terraform.tfstate` exists, terraform will evaluate `data.aws_route53_zone.hosted_zone` in this module which naturally fails since no infrastructure exists and `data` lookups to not fail gracefully.

By creating an explicit dependency `depends_on` on the existence of a RDS resource, this error is avoided.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

https://github.com/rackerlabs/cap-aws-magento has issues as a result of this module. This PR addresses those.

##### If input variables or output variables have changed or has been added, have you updated the README?

N/A

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.