### PR TITLE
Remove data lookup for R53 zone ID and variable all R53 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Full working references are available at [examples](examples)
 | family | Parameter Group Family Name (ex. mysql5.7,sqlserver-se-12.0,postgres9.5,oracle-se-12.1,mariadb10.1) | string | `""` | no |
 | iam\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
 | instance\_class | The database instance type. | string | n/a | yes |
-| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone. i.e. alb.aws.com | string | `""` | no |
-| internal\_zone\_name | TLD for Internal Hosted Zone. i.e. mycompany.local | string | `""` | no |
+| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone | string | `""` | no |
+| internal\_zone\_id | The Route53 Internal Hosted Zone ID | string | `""` | no |
+| internal\_zone\_name | TLD for Internal Hosted Zone | string | `""` | no |
 | kms\_key\_id | KMS Key Arn to use for storage encryption. (OPTIONAL) | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
 | maintenance\_window | The daily time range during which automated backups are created if automated backups are enabled. | string | `"Sun:07:00-Sun:08:00"` | no |

--- a/main.tf
+++ b/main.tf
@@ -423,23 +423,12 @@ resource "aws_db_event_subscription" "default" {
   source_ids       = ["${aws_db_instance.db_instance.id}"]
 }
 
-data "aws_route53_zone" "hosted_zone" {
-  count = "${var.internal_record_name != "" ? 1 : 0}"
-
-  depends_on = ["aws_db_instance.db_instance"]
-
-  name         = "${var.internal_zone_name}"
-  private_zone = true
-}
-
 resource "aws_route53_record" "zone_record_alias" {
   count = "${var.internal_record_name != "" ? 1 : 0}"
 
-  depends_on = ["aws_db_instance.db_instance"]
-
-  name    = "${var.internal_record_name}.${data.aws_route53_zone.hosted_zone.name}"
+  name    = "${var.internal_record_name}.${var.internal_zone_name}"
   ttl     = "300"
   type    = "CNAME"
-  zone_id = "${data.aws_route53_zone.hosted_zone.zone_id}"
+  zone_id = "${var.internal_zone_id}"
   records = ["${aws_db_instance.db_instance.address}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -298,13 +298,19 @@ variable "iam_authentication_enabled" {
 }
 
 variable "internal_record_name" {
-  description = "Record Name for the new Resource Record in the Internal Hosted Zone. i.e. alb.aws.com"
+  description = "Record Name for the new Resource Record in the Internal Hosted Zone"
+  type        = "string"
+  default     = ""
+}
+
+variable "internal_zone_id" {
+  description = "The Route53 Internal Hosted Zone ID"
   type        = "string"
   default     = ""
 }
 
 variable "internal_zone_name" {
-  description = "TLD for Internal Hosted Zone. i.e. mycompany.local"
+  description = "TLD for Internal Hosted Zone"
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
None
##### Summary of change(s):
Remove data object for Route 53 lookup as there were potential issues with it:
- v0.0.7 changes saw it as something to plan every time
- v0.0.6 had issues if a destruction failed and the intended zone was removed, the next destruction would fail
- potential conflicts in use cases where multiple of the same zone name may exist in an environment
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.