### PR TITLE
RDS storage auto scaling - maximum storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | kms\_key\_id | KMS Key Arn to use for storage encryption. (OPTIONAL) | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
 | maintenance\_window | The daily time range during which automated backups are created if automated backups are enabled. | string | `"Sun:07:00-Sun:08:00"` | no |
+| max\_storage\_size | Select Max RDS Volume Size in GB. Value other than 0 will enable storage autoscaling | string | `"0"` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
 | multi\_az | Create a multi-AZ RDS database instance | string | `"true"` | no |
 | name | The name prefix to use for the resources created in this module. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -218,11 +218,12 @@ resource "aws_db_instance" "db_instance" {
 
   deletion_protection = "${var.enable_deletion_protection}"
 
-  allocated_storage = "${local.storage_size}"
-  storage_type      = "${var.storage_type}"
-  storage_encrypted = "${var.storage_encrypted}"
-  iops              = "${var.storage_iops}"
-  kms_key_id        = "${var.kms_key_id}"
+  allocated_storage     = "${local.storage_size}"
+  max_allocated_storage = "${var.max_storage_size}"
+  storage_type          = "${var.storage_type}"
+  storage_encrypted     = "${var.storage_encrypted}"
+  iops                  = "${var.storage_iops}"
+  kms_key_id            = "${var.kms_key_id}"
 
   name                                = "${var.dbname}"
   username                            = "${var.username}"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.0"
   region  = "us-west-2"
 }
 
@@ -173,4 +173,6 @@ module "rds_postgres" {
   password            = "${random_string.password.result}"
   create_option_group = false
   skip_final_snapshot = true
+  storage_size        = 100
+  max_storage_size    = 200
 }

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "storage_size" {
   default     = ""
 }
 
+variable "max_storage_size" {
+  description = "Select Max RDS Volume Size in GB. Value other than 0 will enable storage autoscaling"
+  type        = "string"
+  default     = "0"
+}
+
 variable "storage_type" {
   description = "Select RDS Volume Type."
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - addig max_allocated_storage , this is feature RDS storage autoscaling.

##### Summary of change(s):

##### Reason for Change(s):

- rds storage autoscaling was available from June. Adding this as a parameter.
https://aws.amazon.com/about-aws/whats-new/2019/06/rds-storage-auto-scaling/

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No , default is set to 0 , means turned off.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Do examples need to be updated based on changes?

Yes , You will require to use AWS provider later 2.0 version.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
