### PR TITLE
Postgres11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This module creates an RDS instance.  It currently supports master, replica, and
 
 ## Basic Usage
 
-```
+```HCL
 module "rds" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
- subnets           = "${module.vpc.private_subnets}" #  Required
- security_groups   = ["${module.vpc.default_sg}"]    #  Required
- name              = "sample-mysql-rds"              #  Required
- engine            = "mysql"                         #  Required
- instance_class    = "db.t2.large"                   #  Required
- storage_encrypted = true                            #  Parameter defaults to false, but enabled for Cross Region Replication example
- password = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}" #  Required
+  subnets           = "${module.vpc.private_subnets}" #  Required
+  security_groups   = ["${module.vpc.default_sg}"]    #  Required
+  name              = "sample-mysql-rds"              #  Required
+  engine            = "mysql"                         #  Required
+  instance_class    = "db.t2.large"                   #  Required
+  storage_encrypted = true                            #  Parameter defaults to false, but enabled for Cross Region Replication example
+  password = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}" #  Required
 }
 ```
 
@@ -63,7 +63,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | existing\_option\_group\_name | The existing option group to use for this instance. (OPTIONAL) | string | `""` | no |
 | existing\_parameter\_group\_name | The existing parameter group to use for this instance. (OPTIONAL) | string | `""` | no |
 | existing\_subnet\_group | The existing DB subnet group to use for this instance (OPTIONAL) | string | `""` | no |
-| family | Parameter Group Family Name (ex. mysql5.7,sqlserver-se-12.0,postgres9.5,oracle-se-12.1,mariadb10.1) | string | `""` | no |
+| family | Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, oracle-se-12.1, mariadb10.1) | string | `""` | no |
 | final\_snapshot\_suffix | string appended to the final snapshot name with a `-` delimiter | string | `""` | no |
 | iam\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
 | instance\_class | The database instance type. | string | n/a | yes |

--- a/examples/mariadb.tf
+++ b/examples/mariadb.tf
@@ -16,13 +16,13 @@ data "aws_kms_secrets" "rds_credentials" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   vpc_name = "Test1VPC"
 }
 
 module "vpc_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   providers = {
     aws = "aws.oregon"
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -125,7 +125,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -216,7 +216,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   providers = {
     aws = "aws.oregon"

--- a/examples/mssql.tf
+++ b/examples/mssql.tf
@@ -11,13 +11,13 @@ data "aws_kms_secrets" "rds_credentials" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   vpc_name = "Test1VPC"
 }
 
 module "rds_mssql" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration

--- a/examples/mysql.tf
+++ b/examples/mysql.tf
@@ -16,13 +16,13 @@ data "aws_kms_secrets" "rds_credentials" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   vpc_name = "Test1VPC"
 }
 
 module "vpc_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   providers = {
     aws = "aws.oregon"
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -125,7 +125,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -216,7 +216,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   providers = {
     aws = "aws.oregon"

--- a/examples/oracle.tf
+++ b/examples/oracle.tf
@@ -11,13 +11,13 @@ data "aws_kms_secrets" "rds_credentials" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   vpc_name = "Test1VPC"
 }
 
 module "rds_oracle" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration

--- a/examples/postgres.tf
+++ b/examples/postgres.tf
@@ -16,13 +16,13 @@ data "aws_kms_secrets" "rds_credentials" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   vpc_name = "Test1VPC"
 }
 
 module "vpc_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
 
   providers = {
     aws = "aws.oregon"
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -76,7 +76,7 @@ module "rds_master" {
   ##################
 
   # dbname                = "mydb"
-  # engine_version        = "10.3"
+  # engine_version        = "11.5"
   # port                  = "5432"
   # copy_tags_to_snapshot = true
   timezone = "US/Central"
@@ -91,7 +91,7 @@ module "rds_master" {
 
   # publicly_accessible           = false
   # auto_minor_version_upgrade    = true
-  # family                        = "postgres10.3"
+  # family                        = "postgres11"
   # multi_az                      = false
   # storage_encrypted             = false
   # kms_key_id                    = "some-kms-key-id"
@@ -130,7 +130,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   ##################
   # Required Configuration
@@ -168,7 +168,7 @@ module "rds_replica" {
   ##################
 
   # dbname                = "mydb"
-  # engine_version        = "10.3"
+  # engine_version        = "11.5"
   # port                  = "5432"
   # copy_tags_to_snapshot = true
   timezone = "US/Central"
@@ -183,7 +183,7 @@ module "rds_replica" {
 
   # publicly_accessible           = false
   # auto_minor_version_upgrade    = true
-  # family                        = "postgres10.3"
+  # family                        = "postgres11"
   # multi_az                      = false
   # storage_encrypted             = false
   # kms_key_id                    = "some-kms-key-id"
@@ -215,7 +215,7 @@ module "rds_replica" {
 }
 
 ####################################################################################################
-# Postgres Cross Region Replica                                                                     #
+# Postgres Cross Region Replica                                                                    #
 ####################################################################################################
 
 data "aws_kms_alias" "rds_crr" {
@@ -224,7 +224,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
 
   providers = {
     aws = "aws.oregon"
@@ -266,7 +266,7 @@ module "rds_cross_region_replica" {
   ##################
 
   # dbname                = "mydb"
-  # engine_version        = "10.3"
+  # engine_version        = "11.5"
   # port                  = "5432"
   # copy_tags_to_snapshot = true
   # timezone              = "US/Central"
@@ -280,7 +280,7 @@ module "rds_cross_region_replica" {
 
   # publicly_accessible           = false
   # auto_minor_version_upgrade    = true
-  # family                        = "postgres10.3"
+  # family                        = "postgres11"
   # multi_az                      = false
   # storage_encrypted             = false
   # kms_key_id                    = "some-kms-key-id"

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,23 @@
 /**
  * # aws-terraform-rds
  *
- *This module creates an RDS instance.  It currently supports master, replica, and cross region replica RDS instances.
+ * This module creates an RDS instance.  It currently supports master, replica, and cross region replica RDS instances.
  *
- *## Basic Usage
+ * ## Basic Usage
  *
- *```
- *module "rds" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.6"
+ * ```HCL
+ * module "rds" {
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.13"
  *
- *  subnets           = "${module.vpc.private_subnets}" #  Required
- *  security_groups   = ["${module.vpc.default_sg}"]    #  Required
- *  name              = "sample-mysql-rds"              #  Required
- *  engine            = "mysql"                         #  Required
- *  instance_class    = "db.t2.large"                   #  Required
- *  storage_encrypted = true                            #  Parameter defaults to false, but enabled for Cross Region Replication example
- *  password = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}" #  Required
- *}
- *```
+ *   subnets           = "${module.vpc.private_subnets}" #  Required
+ *   security_groups   = ["${module.vpc.default_sg}"]    #  Required
+ *   name              = "sample-mysql-rds"              #  Required
+ *   engine            = "mysql"                         #  Required
+ *   instance_class    = "db.t2.large"                   #  Required
+ *   storage_encrypted = true                            #  Parameter defaults to false, but enabled for Cross Region Replication example
+ *   password = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}" #  Required
+ * }
+ * ```
  *
  * Full working references are available at [examples](examples)
  * ## Limitations
@@ -40,6 +40,7 @@ locals {
   is_oracle     = "${local.engine_class == "oracle"}"                                            # To allow setting Oracle specific settings
   is_postgres   = "${local.engine_class == "postgres"}"
   is_postgres10 = "${local.engine_class == "postgres" && local.postgres_major_version == "10" }" # To allow setting postgresql specific settings
+  is_postgres11 = "${local.engine_class == "postgres" && local.postgres_major_version == "11" }" # To allow setting postgresql specific settings
 
   # This map contains default values for several properties if they are explicitly defined.
   # Should be occasionally updated as newer engine versions are released
@@ -62,7 +63,7 @@ locals {
 
     postgres = {
       port       = "5432"
-      version    = "10.3"
+      version    = "11.5"
       jdbc_proto = "postgresql"
     }
 
@@ -111,7 +112,7 @@ locals {
 
   # Break up the engine version in to chunks to get the major version part.  This is a single number for PostgreSQL10
   # and two numbers for all other engines (ex: 5.7).
-  version_chunk = "${chunklist(split(".", local.engine_version), local.is_postgres10 ? 1 : 2)}"
+  version_chunk = "${chunklist(split(".", local.engine_version), local.is_postgres10 || local.is_postgres11 ? 1 : 2)}"
 
   major_version = "${join(".", local.version_chunk[0])}"
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "rds" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds//?ref=v0.0.13"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
  *
  *   subnets           = "${module.vpc.private_subnets}" #  Required
  *   security_groups   = ["${module.vpc.default_sg}"]    #  Required
@@ -41,21 +41,22 @@ locals {
   is_postgres   = "${local.engine_class == "postgres"}"
   is_postgres10 = "${local.engine_class == "postgres" && local.postgres_major_version == "10" }" # To allow setting postgresql specific settings
   is_postgres11 = "${local.engine_class == "postgres" && local.postgres_major_version == "11" }" # To allow setting postgresql specific settings
+  is_oracle18   = "${local.engine_class == "oracle" && local.oracle_major_version == "18" }"     # To allow setting Oracle specific settings
 
   # This map contains default values for several properties if they are explicitly defined.
   # Should be occasionally updated as newer engine versions are released
   engine_defaults = {
     mariadb = {
-      version = "10.2.12"
+      version = "10.3.13"
     }
 
     mysql = {
-      version = "5.7.21"
+      version = "5.7.26"
     }
 
     oracle = {
       port         = "1521"
-      version      = "12.1.0.2.v12"
+      version      = "18.0.0.0.ru-2019-07.rur-2019-07.r1"
       storage_size = "100"
       license      = "license-included"
       jdbc_proto   = "oracle:thin"
@@ -69,7 +70,7 @@ locals {
 
     sqlserver = {
       port         = "1433"
-      version      = "14.00.3015.40.v1"
+      version      = "14.00.3049.1.v1"
       storage_size = "200"
       license      = "license-included"
       jdbc_proto   = "sqlserver"
@@ -85,6 +86,7 @@ locals {
   storage_size           = "${coalesce(var.storage_size, lookup(local.engine_defaults[local.engine_class], "storage_size", 10))}"
   engine_version         = "${coalesce(var.engine_version, lookup(local.engine_defaults[local.engine_class], "version"))}"
   postgres_major_version = "${element(split(".",local.engine_version), 0)}"
+  oracle_major_version   = "${element(split(".",local.engine_version), 0)}"
 
   license_model = "${coalesce(var.license_model, lookup(local.engine_defaults[local.engine_class], "license", ""))}"
 
@@ -110,9 +112,9 @@ locals {
 
   same_region_replica = "${var.read_replica && length(split(":", var.source_db)) == 1}"
 
-  # Break up the engine version in to chunks to get the major version part.  This is a single number for PostgreSQL10
+  # Break up the engine version in to chunks to get the major version part.  This is a single number for PostgreSQL10/11
   # and two numbers for all other engines (ex: 5.7).
-  version_chunk = "${chunklist(split(".", local.engine_version), local.is_postgres10 || local.is_postgres11 ? 1 : 2)}"
+  version_chunk = "${chunklist(split(".", local.engine_version), local.is_postgres10 || local.is_postgres11 || local.is_oracle18 ? 1 : 2)}"
 
   major_version = "${join(".", local.version_chunk[0])}"
 
@@ -277,7 +279,7 @@ resource "aws_db_instance" "db_instance" {
 }
 
 module "free_storage_space_alarm_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_description        = "Free storage space has fallen below threshold, generating ticket."
   alarm_name               = "${var.name}-free-storage-space-ticket"
@@ -299,7 +301,7 @@ module "free_storage_space_alarm_ticket" {
 }
 
 module "replica_lag_alarm_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_count              = "${var.read_replica ? 1 : 0}"
   alarm_description        = "ReplicaLag has exceeded threshold, generating ticket.."
@@ -322,7 +324,7 @@ module "replica_lag_alarm_ticket" {
 }
 
 module "free_storage_space_alarm_email" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_description        = "Free storage space has fallen below threshold, sending email notification."
   alarm_name               = "${var.name}-free-storage-space-email"
@@ -343,7 +345,7 @@ module "free_storage_space_alarm_email" {
 }
 
 module "write_iops_high_alarm_email" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_description        = "Alarm if WriteIOPs > ${var.alarm_write_iops_limit} for 5 minutes"
   alarm_name               = "${var.name}-write-iops-high-email"
@@ -364,7 +366,7 @@ module "write_iops_high_alarm_email" {
 }
 
 module "read_iops_high_alarm_email" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_description        = "Alarm if ReadIOPs > ${var.alarm_read_iops_limit} for 5 minutes"
   alarm_name               = "${var.name}-read-iops-high-email"
@@ -385,7 +387,7 @@ module "read_iops_high_alarm_email" {
 }
 
 module "cpu_high_alarm_email" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_description        = "Alarm if CPU > ${var.alarm_cpu_limit} for 15 minutes"
   alarm_name               = "${var.name}-cpu-high-email"
@@ -406,7 +408,7 @@ module "cpu_high_alarm_email" {
 }
 
 module "replica_lag_alarm_email" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm?ref=v0.0.1"
 
   alarm_count              = "${var.read_replica ? 1 : 0}"
   alarm_description        = "ReplicaLag has exceeded threshold."

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -12,6 +12,14 @@ provider "random" {
   version = "~> 1.0"
 }
 
+resource "random_string" "identifier" {
+  length  = 6
+  special = false
+  lower   = true
+  upper   = false
+  number  = false
+}
+
 resource "random_string" "password" {
   length      = 16
   special     = false
@@ -31,7 +39,7 @@ resource "random_string" "mssql_name" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
 
-  vpc_name = "Test1VPC"
+  vpc_name = "${random_string.identifier.result}VPC-1"
 }
 
 module "vpc_dr" {
@@ -41,20 +49,20 @@ module "vpc_dr" {
     aws = "aws.ohio"
   }
 
-  vpc_name = "Test2VPC"
+  vpc_name = "${random_string.identifier.result}VPC-2"
 }
 
 ########################
 #         MySQL        #
 ########################
-module "rds_mysql" {
+module "rds_mysql_latest" {
   source = "../../module"
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test-mysql-rds"
+  name                = "mysql-${random_string.identifier.result}"
   engine              = "mysql"
-  instance_class      = "db.t2.large"
+  instance_class      = "db.t3.large"
   storage_encrypted   = true
   password            = "${random_string.password.result}"
   create_option_group = false
@@ -64,20 +72,20 @@ module "rds_mysql" {
 ########################
 #       Replica        #
 ########################
-module "rds_replica" {
+module "rds_replica_latest" {
   source = "../../module"
 
   subnets                = "${module.vpc.private_subnets}"
   security_groups        = ["${module.vpc.default_sg}"]
   create_subnet_group    = false
-  name                   = "test-mysql-rds-rr"
+  name                   = "mysql-${random_string.identifier.result}-rr"
   engine                 = "mysql"
-  instance_class         = "db.t2.large"
+  instance_class         = "db.t3.large"
   storage_encrypted      = true
   create_parameter_group = false
   create_option_group    = false
   read_replica           = true
-  source_db              = "${module.rds_mysql.db_instance}"
+  source_db              = "${module.rds_mysql_latest.db_instance}"
   password               = ""
 }
 
@@ -90,7 +98,7 @@ data "aws_kms_alias" "rds_crr" {
   name     = "alias/aws/rds"
 }
 
-module "rds_cross_region_replica" {
+module "rds_cross_region_replica_latest" {
   source = "../../module"
 
   providers = {
@@ -99,27 +107,27 @@ module "rds_cross_region_replica" {
 
   subnets           = "${module.vpc_dr.private_subnets}"
   security_groups   = ["${module.vpc_dr.default_sg}"]
-  name              = "test-mysql-rds-crr"
+  name              = "mysql-${random_string.identifier.result}-crr"
   engine            = "mysql"
-  instance_class    = "db.t2.large"
+  instance_class    = "db.t3.large"
   storage_encrypted = true
   kms_key_id        = "${data.aws_kms_alias.rds_crr.target_key_arn}"
   password          = ""
   read_replica      = true
-  source_db         = "${module.rds_mysql.db_instance_arn}"
+  source_db         = "${module.rds_mysql_latest.db_instance_arn}"
 }
 
 ########################
 #       MariaDB        #
 ########################
-module "rds_mariadb" {
+module "rds_mariadb_latest" {
   source = "../../module"
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test-mariadb-rds"
+  name                = "mariadb-${random_string.identifier.result}"
   engine              = "mariadb"
-  instance_class      = "db.t2.large"
+  instance_class      = "db.t3.large"
   storage_encrypted   = true
   password            = "${random_string.password.result}"
   create_option_group = false
@@ -129,14 +137,14 @@ module "rds_mariadb" {
 ########################
 #        MS SQL        #
 ########################
-module "rds_mssql" {
+module "rds_mssql_latest" {
   source = "../../module"
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "${random_string.mssql_name.result}"
+  name                = "mssql-${random_string.identifier.result}"
   engine              = "sqlserver-se"
-  instance_class      = "db.m4.large"
+  instance_class      = "db.m5.large"
   password            = "${random_string.password.result}"
   create_option_group = false
   skip_final_snapshot = true
@@ -145,14 +153,14 @@ module "rds_mssql" {
 ########################
 #        Oracle        #
 ########################
-module "rds_oracle" {
+module "rds_oracle_latest" {
   source = "../../module"
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test-oracle-rds"
+  name                = "oracle-${random_string.identifier.result}"
   engine              = "oracle-se2"
-  instance_class      = "db.t2.large"
+  instance_class      = "db.t3.large"
   password            = "${random_string.password.result}"
   create_option_group = false
   skip_final_snapshot = true
@@ -161,14 +169,14 @@ module "rds_oracle" {
 ########################
 #       Postgres       #
 ########################
-module "rds_postgres" {
+module "rds_postgres_latest" {
   source = "../../module"
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test-postgres-rds"
+  name                = "postgres-${random_string.identifier.result}"
   engine              = "postgres"
-  instance_class      = "db.t2.large"
+  instance_class      = "db.t3.large"
   storage_encrypted   = true
   password            = "${random_string.password.result}"
   create_option_group = false

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "existing_parameter_group_name" {
 }
 
 variable "family" {
-  description = "Parameter Group Family Name (ex. mysql5.7,sqlserver-se-12.0,postgres9.5,oracle-se-12.1,mariadb10.1)"
+  description = "Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, oracle-se-12.1, mariadb10.1)"
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
<!-- - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section -->

Raised by @brun0d in Slack

##### Summary of change(s):

When trying to use a specific version of Postgres the module was throwing an error because it was not using the same logic as Postgres 10 to split out the major version from the minor version.

##### Reason for Change(s):

<!-- - If a bug, describe error scenario, including expected behavior and actual behavior. -->
<!-- - If an enhancement, describe the use case and the perceived benefit(s). -->

When setting `engine` to `postgres` and `engine_version` to `11` you got the latest version of Postgres, 11.5. BE needed 11.2. If setting `engine_version` to `11.2` an error was thrown stating the version needed to be major only.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Done

##### Do examples need to be updated based on changes?

Done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
