### PR TITLE
Adding support for setting a full id for db_instance only

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | max\_storage\_size | Select Max RDS Volume Size in GB. Value other than 0 will enable storage autoscaling | `number` | `0` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
 | multi\_az | Create a multi-AZ RDS database instance | `bool` | `true` | no |
-| name | The name prefix to use for the resources created in this module. | `string` | n/a | yes |
+| name | The name to use for the resources created in this module. This is interpreted differently depending on the 'name\_is\_wholename' variable, but only for the instance name, all other resources treat the value as a prefix. | `string` | n/a | yes |
+| name\_is\_wholename | If 'false'  the 'name' variable is treated as a prefix, otherwise it is treated as the wholename for the db\_instance only - other resources still use it as a prefix. This variable eases the process of importing a db instance into the module's namespace (e.g.in a restore situation). | `bool` | `false` | no |
 | notification\_topic | SNS Topic ARN to use for customer notifications from CloudWatch alarms. (OPTIONAL) | `string` | `""` | no |
 | options | List of custom options to apply to the option group. | `list` | `[]` | no |
 | parameters | List of custom parameters to apply to the parameter group. | `list(map(string))` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,8 @@ resource "aws_db_instance" "db_instance" {
   engine_version                        = local.engine_version
   final_snapshot_identifier             = lower("${var.name}-final-snapshot${var.final_snapshot_suffix == "" ? "" : "-"}${var.final_snapshot_suffix}")
   iam_database_authentication_enabled   = var.iam_authentication_enabled
-  identifier_prefix                     = "${lower(var.name)}-"
+  identifier                            = var.name_is_wholename ? lower(var.name) : null
+  identifier_prefix                     = var.name_is_wholename ? null : "${lower(var.name)}-"
   instance_class                        = var.instance_class
   iops                                  = var.storage_iops
   kms_key_id                            = var.kms_key_id

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -74,6 +74,24 @@ module "rds_mysql_8" {
   subnets             = module.vpc.private_subnets
 }
 
+
+###### Full indentifier provided ########
+module "rds_mysql_whole_indentifier" {
+  source = "../../module"
+
+  create_option_group = false
+  engine              = "mysql"
+  instance_class      = "db.t3.large"
+  name                = "mysql-noprefix-${random_string.identifier.result}"
+  name_is_wholename   = true
+  password            = random_string.password.result
+  security_groups     = [module.vpc.default_sg]
+  skip_final_snapshot = true
+  storage_encrypted   = true
+  subnets             = module.vpc.private_subnets
+}
+
+
 ########################
 #       Replica        #
 ########################

--- a/variables.tf
+++ b/variables.tf
@@ -256,8 +256,14 @@ variable "multi_az" {
 }
 
 variable "name" {
-  description = "The name prefix to use for the resources created in this module."
+  description = "The name to use for the resources created in this module. This is interpreted differently depending on the 'name_is_wholename' variable, but only for the instance name, all other resources treat the value as a prefix."
   type        = string
+}
+
+variable "name_is_wholename" {
+  description = "If 'false'  the 'name' variable is treated as a prefix, otherwise it is treated as the wholename for the db_instance only - other resources still use it as a prefix. This variable eases the process of importing a db instance into the module's namespace (e.g.in a restore situation)."
+  type        = bool
+  default     = false
 }
 
 variable "notification_topic" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section
https://jira.rax.io/browse/MPCSUPENG-1623

##### Summary of change(s):
adding support for set full Identifier for the db instance.  Useful for terraform imports in DR scenarios.
##### Reason for Change(s):
N/A
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
no
