### PR TITLE
Update RDS engine defaults (HLC1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates an RDS instance.  It currently supports master, replica, and
 
 ```HCL
 module "rds" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   subnets           = "${module.vpc.private_subnets}" #  Required
   security_groups   = ["${module.vpc.default_sg}"]    #  Required
@@ -22,81 +22,87 @@ Full working references are available at [examples](examples)
 ## Limitations
 
 - Terraform does not support joining a Microsoft SQL RDS instance to a Directory Service at this time.  This has been requested in https://github.com/terraform-providers/terraform-provider-aws/pull/5378 and can be added once that functionality is present.
-## Other TF Modules Used
-Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
-	- free_storage_space_alarm_ticket
-	- replica_lag_alarm_ticket
-	- free_storage_space_alarm_email
-	- write_iops_high_alarm_email
-	- read_iops_high_alarm_email
-	- cpu_high_alarm_email
-	- replica_lag_alarm_email
+## Other TF Modules Used  
+Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
+	- free\_storage\_space\_alarm\_ticket
+	- replica\_lag\_alarm\_ticket
+	- free\_storage\_space\_alarm\_email
+	- write\_iops\_high\_alarm\_email
+	- read\_iops\_high\_alarm\_email
+	- cpu\_high\_alarm\_email
+	- replica\_lag\_alarm\_email
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alarm\_cpu\_limit | CloudWatch CPUUtilization Threshold | string | `"60"` | no |
-| alarm\_free\_space\_limit | CloudWatch Free Storage Space Limit Threshold (Bytes) | string | `"1024000000"` | no |
-| alarm\_read\_iops\_limit | CloudWatch Read IOPSLimit Threshold | string | `"100"` | no |
-| alarm\_write\_iops\_limit | CloudWatch Write IOPSLimit Threshold | string | `"100"` | no |
-| apply\_immediately | Should database modifications be applied immediately? | string | `"false"` | no |
-| auto\_minor\_version\_upgrade | Boolean value that indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
-| backup\_retention\_period | The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Compass best practice is 30 or more days. | string | `"35"` | no |
-| backup\_window | The daily time range during which automated backups are created if automated backups are enabled. | string | `"05:00-06:00"` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information. | string | `""` | no |
-| copy\_tags\_to\_snapshot | Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. | string | `"true"` | no |
-| create\_option\_group | A boolean variable noting if a new option group should be created. | string | `"true"` | no |
-| create\_parameter\_group | A boolean variable noting if a new parameter group should be created. | string | `"true"` | no |
-| create\_subnet\_group | A boolean variable noting if a new DB subnet group should be created. | string | `"true"` | no |
-| db\_instance\_create\_timeout | Timeout for creating instances, replicas, and restoring from Snapshots | string | `"60m"` | no |
-| db\_instance\_delete\_timeout | Timeout for destroying databases. This includes the time required to take snapshots | string | `"60m"` | no |
-| db\_instance\_update\_timeout | Timeout for datbabse modifications | string | `"80m"` | no |
-| db\_snapshot\_id | The name of a DB snapshot (optional). | string | `""` | no |
-| dbname | The DB name to create. If omitted, no database is created initially | string | `""` | no |
-| enable\_deletion\_protection | If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true. The default is false. | string | `"false"` | no |
-| engine | Database Engine Type.  Allowed values: mariadb, mysql, oracle-ee, oracle-se, oracle-se1, oracle-se2, postgres, sqlserver-ee, sqlserver-ex, sqlserver-se, sqlserver-web | string | n/a | yes |
-| engine\_version | Database Engine Minor Version http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html | string | `""` | no |
-| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
-| event\_categories | A list of RDS event categories.  Submissions will be made to the provided NotificationTopic for each matching event. Acceptable values can be found with the CLI command 'aws rds describe-event-categories' (OPTIONAL) | list | `<list>` | no |
-| existing\_monitoring\_role | ARN of an existing enhanced monitoring role to use for this instance. (OPTIONAL) | string | `""` | no |
-| existing\_option\_group\_name | The existing option group to use for this instance. (OPTIONAL) | string | `""` | no |
-| existing\_parameter\_group\_name | The existing parameter group to use for this instance. (OPTIONAL) | string | `""` | no |
-| existing\_subnet\_group | The existing DB subnet group to use for this instance (OPTIONAL) | string | `""` | no |
-| family | Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, oracle-se-12.1, mariadb10.1) | string | `""` | no |
-| final\_snapshot\_suffix | string appended to the final snapshot name with a `-` delimiter | string | `""` | no |
-| iam\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
-| instance\_class | The database instance type. | string | n/a | yes |
-| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone | string | `""` | no |
-| internal\_zone\_id | The Route53 Internal Hosted Zone ID | string | `""` | no |
-| internal\_zone\_name | TLD for Internal Hosted Zone | string | `""` | no |
-| kms\_key\_id | KMS Key Arn to use for storage encryption. (OPTIONAL) | string | `""` | no |
-| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
-| maintenance\_window | The daily time range during which automated backups are created if automated backups are enabled. | string | `"Sun:07:00-Sun:08:00"` | no |
-| max\_storage\_size | Select Max RDS Volume Size in GB. Value other than 0 will enable storage autoscaling | string | `"0"` | no |
-| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
-| multi\_az | Create a multi-AZ RDS database instance | string | `"true"` | no |
-| name | The name prefix to use for the resources created in this module. | string | n/a | yes |
-| notification\_topic | SNS Topic ARN to use for customer notifications from CloudWatch alarms. (OPTIONAL) | string | `""` | no |
-| options | List of custom options to apply to the option group. | list | `<list>` | no |
-| parameters | List of custom parameters to apply to the parameter group. | list | `<list>` | no |
-| password | Password for the local administrator account. | string | n/a | yes |
-| port | The port on which the DB accepts connections | string | `""` | no |
-| publicly\_accessible | Boolean value that indicates whether the database instance is an Internet-facing instance. | string | `"false"` | no |
-| rackspace\_alarms\_enabled | Specifies whether non-emergency rackspace alarms will create a ticket. | string | `"false"` | no |
-| rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `"true"` | no |
-| read\_replica | Specifies whether this RDS instance is a read replica. | string | `"false"` | no |
-| security\_groups | A list of EC2 security groups to assign to this resource | list | n/a | yes |
-| skip\_final\_snapshot | Boolean value to control if the DB instance will take a final snapshot when destroyed.  This value should be set to false if a final snapshot is desired. | string | `"false"` | no |
-| source\_db | The ID of the source DB instance.  For cross region replicas, the full ARN should be provided | string | `""` | no |
-| storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
-| storage\_iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
-| storage\_size | Select RDS Volume Size in GB. | string | `""` | no |
-| storage\_type | Select RDS Volume Type. | string | `"gp2"` | no |
-| subnets | Subnets for RDS Instances | list | n/a | yes |
-| tags | Custom tags to apply to all resources. | map | `<map>` | no |
-| timezone | The server time zone | string | `""` | no |
-| username | The name of master user for the client DB instance. | string | `"dbadmin"` | no |
+|------|-------------|------|---------|:-----:|
+| alarm\_cpu\_limit | CloudWatch CPUUtilization Threshold | `string` | `60` | no |
+| alarm\_free\_space\_limit | CloudWatch Free Storage Space Limit Threshold (Bytes) | `string` | `1024000000` | no |
+| alarm\_read\_iops\_limit | CloudWatch Read IOPSLimit Threshold | `string` | `100` | no |
+| alarm\_write\_iops\_limit | CloudWatch Write IOPSLimit Threshold | `string` | `100` | no |
+| apply\_immediately | Should database modifications be applied immediately? | `string` | `false` | no |
+| auto\_minor\_version\_upgrade | Boolean value that indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `string` | `true` | no |
+| backup\_retention\_period | The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Compass best practice is 30 or more days. | `string` | `35` | no |
+| backup\_window | The daily time range during which automated backups are created if automated backups are enabled. | `string` | `"05:00-06:00"` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information. | `string` | `""` | no |
+| copy\_tags\_to\_snapshot | Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. | `string` | `true` | no |
+| create\_option\_group | A boolean variable noting if a new option group should be created. | `string` | `true` | no |
+| create\_parameter\_group | A boolean variable noting if a new parameter group should be created. | `string` | `true` | no |
+| create\_subnet\_group | A boolean variable noting if a new DB subnet group should be created. | `string` | `true` | no |
+| db\_instance\_create\_timeout | Timeout for creating instances, replicas, and restoring from Snapshots | `string` | `"60m"` | no |
+| db\_instance\_delete\_timeout | Timeout for destroying databases. This includes the time required to take snapshots | `string` | `"60m"` | no |
+| db\_instance\_update\_timeout | Timeout for datbabse modifications | `string` | `"80m"` | no |
+| db\_snapshot\_id | The name of a DB snapshot (optional). | `string` | `""` | no |
+| dbname | The DB name to create. If omitted, no database is created initially | `string` | `""` | no |
+| enable\_deletion\_protection | If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true. The default is false. | `string` | `false` | no |
+| engine | Database Engine Type.  Allowed values: mariadb, mysql, oracle-ee, oracle-se, oracle-se1, oracle-se2, postgres, sqlserver-ee, sqlserver-ex, sqlserver-se, sqlserver-web | `string` | n/a | yes |
+| engine\_version | Database Engine Minor Version http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html | `string` | `""` | no |
+| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
+| event\_categories | A list of RDS event categories.  Submissions will be made to the provided NotificationTopic for each matching event. Acceptable values can be found with the CLI command 'aws rds describe-event-categories' (OPTIONAL) | `list` | `[]` | no |
+| existing\_monitoring\_role | ARN of an existing enhanced monitoring role to use for this instance. (OPTIONAL) | `string` | `""` | no |
+| existing\_option\_group\_name | The existing option group to use for this instance. (OPTIONAL) | `string` | `""` | no |
+| existing\_parameter\_group\_name | The existing parameter group to use for this instance. (OPTIONAL) | `string` | `""` | no |
+| existing\_subnet\_group | The existing DB subnet group to use for this instance (OPTIONAL) | `string` | `""` | no |
+| family | Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, postgres12, oracle-se-12.1, mariadb10.1) | `string` | `""` | no |
+| final\_snapshot\_suffix | string appended to the final snapshot name with a `-` delimiter | `string` | `""` | no |
+| iam\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `string` | `false` | no |
+| instance\_class | The database instance type. | `string` | n/a | yes |
+| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone | `string` | `""` | no |
+| internal\_zone\_id | The Route53 Internal Hosted Zone ID | `string` | `""` | no |
+| internal\_zone\_name | TLD for Internal Hosted Zone | `string` | `""` | no |
+| kms\_key\_id | KMS Key Arn to use for storage encryption. (OPTIONAL) | `string` | `""` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `""` | no |
+| maintenance\_window | The daily time range during which automated backups are created if automated backups are enabled. | `string` | `"Sun:07:00-Sun:08:00"` | no |
+| max\_storage\_size | Select Max RDS Volume Size in GB. Value other than 0 will enable storage autoscaling | `string` | `"0"` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `string` | `0` | no |
+| multi\_az | Create a multi-AZ RDS database instance | `string` | `true` | no |
+| name | The name prefix to use for the resources created in this module. | `string` | n/a | yes |
+| notification\_topic | SNS Topic ARN to use for customer notifications from CloudWatch alarms. (OPTIONAL) | `string` | `""` | no |
+| options | List of custom options to apply to the option group. | `list` | `[]` | no |
+| parameters | List of custom parameters to apply to the parameter group. | `list` | `[]` | no |
+| password | Password for the local administrator account. | `string` | n/a | yes |
+| port | The port on which the DB accepts connections | `string` | `""` | no |
+| publicly\_accessible | Boolean value that indicates whether the database instance is an Internet-facing instance. | `string` | `false` | no |
+| rackspace\_alarms\_enabled | Specifies whether non-emergency rackspace alarms will create a ticket. | `string` | `false` | no |
+| rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `string` | `true` | no |
+| read\_replica | Specifies whether this RDS instance is a read replica. | `string` | `false` | no |
+| security\_groups | A list of EC2 security groups to assign to this resource | `list` | n/a | yes |
+| skip\_final\_snapshot | Boolean value to control if the DB instance will take a final snapshot when destroyed.  This value should be set to false if a final snapshot is desired. | `string` | `false` | no |
+| source\_db | The ID of the source DB instance.  For cross region replicas, the full ARN should be provided | `string` | `""` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | `string` | `false` | no |
+| storage\_iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `string` | `0` | no |
+| storage\_size | Select RDS Volume Size in GB. | `string` | `""` | no |
+| storage\_type | Select RDS Volume Type. | `string` | `"gp2"` | no |
+| subnets | Subnets for RDS Instances | `list` | n/a | yes |
+| tags | Custom tags to apply to all resources. | `map` | `{}` | no |
+| timezone | The server time zone | `string` | `""` | no |
+| username | The name of master user for the client DB instance. | `string` | `"dbadmin"` | no |
 
 ## Outputs
 

--- a/examples/mariadb.tf
+++ b/examples/mariadb.tf
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -125,7 +125,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -216,7 +216,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   providers = {
     aws = "aws.oregon"

--- a/examples/mssql.tf
+++ b/examples/mssql.tf
@@ -17,7 +17,7 @@ module "vpc" {
 }
 
 module "rds_mssql" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration

--- a/examples/mysql.tf
+++ b/examples/mysql.tf
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -125,7 +125,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -216,7 +216,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   providers = {
     aws = "aws.oregon"

--- a/examples/oracle.tf
+++ b/examples/oracle.tf
@@ -17,7 +17,7 @@ module "vpc" {
 }
 
 module "rds_oracle" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration

--- a/examples/postgres.tf
+++ b/examples/postgres.tf
@@ -36,7 +36,7 @@ module "vpc_dr" {
 ####################################################################################################
 
 module "rds_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -130,7 +130,7 @@ module "rds_master" {
 ####################################################################################################
 
 module "rds_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   ##################
   # Required Configuration
@@ -224,7 +224,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "rds_cross_region_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rds?ref=v0.0.14"
 
   providers = {
     aws = "aws.oregon"

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "existing_parameter_group_name" {
 }
 
 variable "family" {
-  description = "Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, oracle-se-12.1, mariadb10.1)"
+  description = "Parameter Group Family Name (ex. mysql5.7, sqlserver-se-12.0, postgres9.5, postgres10, postgres11, postgres12, oracle-se-12.1, mariadb10.1)"
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1408](https://jira.rax.io/browse/MPCSUPENG-1408)

##### Summary of change(s):

- Updates RDS engine default versions to latest stable on each engine.
- Streamlines detection of engine versions where the major version is only a single part of the version number
  - This should simplify code and additions of new versions in this category.
  - Updates detection to correctly determine major version for Oracle 19 and Postgres 12

##### Reason for Change(s):

- Simplifies code and eases maintenance of future versions
- Updates defaults to latest versions, reducing later overhead and maintenance

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
NA

##### Do examples need to be updated based on changes?
Example pinnings were updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
